### PR TITLE
Firefox Compatibility

### DIFF
--- a/pages/_error.js
+++ b/pages/_error.js
@@ -12,7 +12,7 @@ const _Error = () => {
 
             <main className="error-text-grad" style={{flex:"1 0 auto",top:"50%",left:"50%",position:"absolute",transform:"translate(-50%,-50%)",zIndex:"1001"}}>
             <h1 className="white-text center font-vt" style={{fontSize:"57px"}}>Error 404</h1>
-                <p className="center font-caveat flow-text white-text" style={{fontSize:"28px"}}>Nothing here! Get back to <a href="/">Home</a>?</p>
+                <p className="error-text-grad center font-caveat flow-text white-text" style={{fontSize:"28px"}}>Nothing here! Get back to <a href="/">Home</a>?</p>
             </main>
             <Particles params={params2} id="particles"/>
         </div>


### PR DESCRIPTION
The `<p>` element was not inheriting the 'error-text-grad' class from `<main>` in firefox, resulting in transparent/invisible font. Thus added the class in the `<p>` element again, which fixes the issue.